### PR TITLE
Fix Vertex API key auth bypass for global models (gemini-3-pro etc.)

### DIFF
--- a/request.py
+++ b/request.py
@@ -605,16 +605,16 @@ async def get_vertex_gemini_payload(request, engine, provider, api_key=None):
     else:
         location = gemini1
 
-    if "google-vertex-ai" in provider.get("base_url", "") or any(global_model in original_model for global_model in global_models):
+    if api_key is not None and len(api_key) > 2 and api_key[2] == ".":
+        url = f"https://aiplatform.googleapis.com/v1/publishers/google/models/{original_model}:{gemini_stream}?key={api_key}"
+        headers.pop("Authorization", None)
+    elif "google-vertex-ai" in provider.get("base_url", "") or any(global_model in original_model for global_model in global_models):
         url = provider.get("base_url").rstrip('/') + "/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{MODEL_ID}:{stream}".format(
             LOCATION=await location.next(),
             PROJECT_ID=project_id,
             MODEL_ID=original_model,
             stream=gemini_stream
         )
-    elif api_key is not None and api_key[2] == ".":
-        url = f"https://aiplatform.googleapis.com/v1/publishers/google/models/{original_model}:{gemini_stream}?key={api_key}"
-        headers.pop("Authorization", None)
     else:
         url = "https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{MODEL_ID}:{stream}".format(
             LOCATION=await location.next(),


### PR DESCRIPTION
API key check (api_key[2] == ".") was placed after the global_models check, so models like gemini-3-pro-preview always used the OAuth2 URL format instead of the ?key= URL format, causing 401 UNAUTHENTICATED.

Move the API key detection before the global_models/cloudflare branch so that API key authentication takes priority.

```
curl "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-3-pro-preview:streamGenerateContent?key=${API_KEY}" \
-X POST \
-H "Content-Type: application/json" \
-d '{
  "contents": [
    {
      "role": "user",
      "parts": [
        {
          "text": "Explain how AI works in a few words"
        }
      ]
    }
  ]
}'
```