### PR TITLE
修复千问模型默认开启思考导致工具调用报错的问题

### DIFF
--- a/models.py
+++ b/models.py
@@ -124,6 +124,7 @@ class RequestModel(BaseRequest):
     tools: Optional[List[Tool]] = None
     response_format: Optional[ResponseFormat] = None
     thinking: Optional[Thinking] = None
+    enable_thinking: Optional[bool] = None
     reasoning: Optional[Reasoning] = Field(default=None, exclude=True)
     service_tier: Optional[str] = Field(default=None, exclude=True)
     stream_options: Optional[StreamOptions] = None

--- a/request.py
+++ b/request.py
@@ -1392,16 +1392,20 @@ async def get_aws_payload(request, engine, provider, api_key=None):
 
     return url, headers, payload
 
-def _fix_qwen3_thinking_tool_choice(payload: dict, original_model: str) -> None:
-    # Qwen3+ models enable thinking by default; the Alibaba API rejects
-    # tool_choice='required' or a specific function object in that mode.
+def _handle_qwen3_thinking_mode(payload: dict, original_model: str) -> None:
+    # Qwen3+ models (e.g. qwen3.5-plus) enable thinking by default, but the
+    # Alibaba API rejects tool_choice='required' or a function object in that
+    # mode.  Default to thinking OFF so standard tool_choice values work; if
+    # the caller explicitly sets enable_thinking=True, keep thinking ON but
+    # downgrade any incompatible tool_choice to 'auto'.
     if "qwen3" not in original_model.lower():
         return
-    if payload.get("enable_thinking") is False:
-        return
-    tool_choice = payload.get("tool_choice")
-    if tool_choice == "required" or isinstance(tool_choice, dict):
-        payload["tool_choice"] = "auto"
+    if payload.get("enable_thinking") is True:
+        tool_choice = payload.get("tool_choice")
+        if tool_choice == "required" or isinstance(tool_choice, dict):
+            payload["tool_choice"] = "auto"
+    else:
+        payload["enable_thinking"] = False
 
 async def get_gpt_payload(request, engine, provider, api_key=None):
     headers = {
@@ -1563,7 +1567,7 @@ async def get_gpt_payload(request, engine, provider, api_key=None):
                 })
 
     apply_post_body_parameter_overrides(payload, provider, request.model)
-    _fix_qwen3_thinking_tool_choice(payload, original_model)
+    _handle_qwen3_thinking_mode(payload, original_model)
 
     return url, headers, payload
 
@@ -2062,7 +2066,7 @@ async def get_openrouter_payload(request, engine, provider, api_key=None):
             payload[field] = value
 
     apply_post_body_parameter_overrides(payload, provider, request.model)
-    _fix_qwen3_thinking_tool_choice(payload, original_model)
+    _handle_qwen3_thinking_mode(payload, original_model)
 
     return url, headers, payload
 

--- a/request.py
+++ b/request.py
@@ -1392,6 +1392,17 @@ async def get_aws_payload(request, engine, provider, api_key=None):
 
     return url, headers, payload
 
+def _fix_qwen3_thinking_tool_choice(payload: dict, original_model: str) -> None:
+    # Qwen3+ models enable thinking by default; the Alibaba API rejects
+    # tool_choice='required' or a specific function object in that mode.
+    if "qwen3" not in original_model.lower():
+        return
+    if payload.get("enable_thinking") is False:
+        return
+    tool_choice = payload.get("tool_choice")
+    if tool_choice == "required" or isinstance(tool_choice, dict):
+        payload["tool_choice"] = "auto"
+
 async def get_gpt_payload(request, engine, provider, api_key=None):
     headers = {
         'Content-Type': 'application/json',
@@ -1552,6 +1563,7 @@ async def get_gpt_payload(request, engine, provider, api_key=None):
                 })
 
     apply_post_body_parameter_overrides(payload, provider, request.model)
+    _fix_qwen3_thinking_tool_choice(payload, original_model)
 
     return url, headers, payload
 
@@ -2050,6 +2062,7 @@ async def get_openrouter_payload(request, engine, provider, api_key=None):
             payload[field] = value
 
     apply_post_body_parameter_overrides(payload, provider, request.model)
+    _fix_qwen3_thinking_tool_choice(payload, original_model)
 
     return url, headers, payload
 

--- a/request.py
+++ b/request.py
@@ -1398,7 +1398,7 @@ def _handle_qwen3_thinking_mode(payload: dict, original_model: str) -> None:
     # mode.  Default to thinking OFF so standard tool_choice values work; if
     # the caller explicitly sets enable_thinking=True, keep thinking ON but
     # downgrade any incompatible tool_choice to 'auto'.
-    if "qwen3" not in original_model.lower():
+    if "qwen" not in original_model.lower():
         return
     if payload.get("enable_thinking") is True:
         tool_choice = payload.get("tool_choice")


### PR DESCRIPTION
<img width="928" height="328" alt="image" src="https://github.com/user-attachments/assets/d22b5ca8-c16c-4be2-90a3-38affd4abb39" />
All qwen3.5-plus error: {'error': {'message': 'Upstream error from Alibaba: <400> InternalError.Algo.InvalidParameter: The tool_choice parameter does not support being set to required or object in thinking mode', 'code': 502}}
