### PR TITLE
fix(vertex): respect base_url in API key auth branch

### DIFF
--- a/request.py
+++ b/request.py
@@ -774,7 +774,8 @@ async def get_vertex_gemini_payload(request, engine, provider, api_key=None):
         location = gemini1
 
     if api_key is not None and len(api_key) > 2 and api_key[2] == ".":
-        url = f"https://aiplatform.googleapis.com/v1/publishers/google/models/{original_model}:{gemini_stream}?key={api_key}"
+        base = (provider.get("base_url") or "https://aiplatform.googleapis.com").rstrip("/")
+        url = f"{base}/v1/publishers/google/models/{original_model}:{gemini_stream}?key={api_key}"
         headers.pop("Authorization", None)
     elif "google-vertex-ai" in provider.get("base_url", "") or any(global_model in original_model for global_model in global_models):
         url = provider.get("base_url").rstrip('/') + "/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{MODEL_ID}:{stream}".format(


### PR DESCRIPTION


`get_vertex_gemini_payload` 里 `?key=` 分支硬编码了全球端点
`https://aiplatform.googleapis.com`，用户在 provider 配置的 `base_url` 被静默忽略。

`aiplatform.googleapis.com` 不是真正的全球 anycast 端点，Google 会根据**客户端源 IP**
就近路由到具体区域。当出口所在区域没有部署目标模型时，请求会 404。

## 复现

容器部署在首尔（或任意亚太出口），执行：

```bash
curl "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-flash-lite:generateContent?key=AQ.xxx" \
  -H "Content-Type: application/json" \
  -d '{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}'
```

返回 404，显式指定区域端点则正常
